### PR TITLE
Better movie embeds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/robot/embeds.py
+++ b/robot/embeds.py
@@ -1,14 +1,93 @@
 import discord
 
 
+class AishaEmbed():
+    '''Embed extensions.'''
+
+    def __init__(self):
+        self.cont = 1
+        self.embed = None
+        self.embeds = []
+
+    def base_movie_embed(self, title_str, description):
+        colour = colour = discord.Colour.random()
+        if self.cont > 1:
+            title = f'{title_str} ({self.cont})'
+            description = 'More movies below'
+        else:
+            title = f'{title_str}'
+
+        self.embed = discord.Embed(
+            title=title, description=description, colour=colour)
+
+    def embed_constrain(self, name, value=None):
+        self.embeds.append(self.embed)
+        self.base_movie_embed()
+        if value:
+            self.embed.add_field(name=name, value=value)
+
+    def process_the(self):
+        processed_movies = []
+        for movie in self.all_movies:
+            if movie[:4] == "The ":
+                movie = movie[4:] + ", The"
+            processed_movies.append(movie)
+        self.all_movies = processed_movies
+
+    def set_all_movies(self):
+        count = 1
+        alphabet = None
+        value = ''
+        self.process_the()
+        for text in sorted(self.all_movies):
+            name = text[0]
+
+            if alphabet is None:
+                alphabet = name
+            embed_len = len(alphabet) + len(value) + \
+                len(self.embed) + len(name)
+            field_len = len(alphabet) + len(value) + len(text) + len(name)
+
+            if embed_len > 5998:
+                count += 1
+                self.cont += 1
+                self.embed_constrain(alphabet)
+
+            if name != alphabet[0]:
+                self.embed.add_field(name=alphabet, value=value)
+                alphabet = name
+                value = text
+                continue
+
+            if field_len > 1022:
+                self.embed.add_field(name=alphabet, value=value)
+                alphabet = f'{name} (cont...)'
+                value = text
+                continue
+
+            if value:
+                value += f'\n{text}'
+            else:
+                value = text
+
+    def format_all_movies_embed(self, all_movies):
+        self.all_movies = all_movies
+        self.cont = 1
+        self.embeds = []
+        self.base_movie_embed(title_str='Movie Watchlist',
+                              description='Movies in the pool of possible watches')
+
+        self.set_all_movies()
+
+        self.embeds.append(self.embed)
+
+        return self.embeds
+
+
 def embed_movie_watchlist(movie_watchlist):
-    if movie_watchlist:
-        description = '\n'.join(movie_watchlist)
-    else:
-        description = '[empty list]'
-    formatted_watchlist = discord.Embed(
-        title='Movie Watchlist', description=description[:1500])
-    return formatted_watchlist
+    embedder = AishaEmbed()
+    responses = embedder.format_all_movies_embed(movie_watchlist)
+    return responses[0]
 
 
 def embed_movie_schedule(schedule, first=False):

--- a/robot/embeds.py
+++ b/robot/embeds.py
@@ -22,7 +22,8 @@ class AishaEmbed():
 
     def embed_constrain(self, name, value=None):
         self.embeds.append(self.embed)
-        self.base_movie_embed()
+        self.base_movie_embed(title_str='Movie Watchlist',
+                              description='More movies below')
         if value:
             self.embed.add_field(name=name, value=value)
 
@@ -87,7 +88,7 @@ class AishaEmbed():
 def embed_movie_watchlist(movie_watchlist):
     embedder = AishaEmbed()
     responses = embedder.format_all_movies_embed(movie_watchlist)
-    return responses[0]
+    return responses
 
 
 def embed_movie_schedule(schedule, first=False):

--- a/robot/requirements.txt
+++ b/robot/requirements.txt
@@ -7,6 +7,7 @@ cachetools==4.1.1
 certifi==2020.6.20
 chardet==3.0.4
 discord.py==1.6.0
+DiscordUtils==1.3.4
 httplib2==0.19.0
 idna==2.10
 multidict==4.7.6

--- a/robot/robot.py
+++ b/robot/robot.py
@@ -3,6 +3,7 @@
 
 import os
 import discord
+import DiscordUtils
 from dotenv import load_dotenv
 from discord.ext import commands
 from pymongo import MongoClient
@@ -198,8 +199,13 @@ async def next_scheduled(ctx):
                 help='See the watchlist')
 async def view_watchlist(ctx):
     watchlist = get_movie_watchlist(MOVIE_COLLECTION)
-    response = embed_movie_watchlist(watchlist)
-    await ctx.send(embed=response)
+    responses = embed_movie_watchlist(watchlist)
+    if len(responses) > 1:
+        paginator = DiscordUtils.Pagination.AutoEmbedPaginator(
+            ctx, timeout=60)
+        await paginator.run(responses)
+    else:
+        await ctx.send(content='', embed=responses[0])
 
 
 @client.command(name='upvotelist',


### PR DESCRIPTION
Modified the `$movielist` embed in the following ways:

- Random colour when embed is called
- Inline fields grouping movies alphabetically
- Movies beginning with "The " are automatically renamed to "<movie name>, The" without changing database entries
- If the embed is over 6,000 characters it will turn into a multipart embed:
![cont](https://user-images.githubusercontent.com/3664960/132913448-f41b6182-37d1-4caf-b57d-2f7a059ab0e1.png)
- If the fields go over their length they turn into multiple fields with "(cont)..." appended: 
![cont 2](https://user-images.githubusercontent.com/3664960/132913577-6e9f28fb-08ff-4d3a-b831-509575604113.png)
